### PR TITLE
fix: "메인페이지 회원별 키워드(다중) 맞춤형 패키지 추천 수정, 패키지 추천 리스트 랜덤 출력으로 수정"

### DIFF
--- a/src/main/java/com/project/tour/controller/HomeController.java
+++ b/src/main/java/com/project/tour/controller/HomeController.java
@@ -55,20 +55,13 @@ public class HomeController {
         System.out.println("메인키워드는: "+ keyword);
         String name = null;
 
-        if(user!=null){
-            model.addAttribute("email",user.getEmail());
-            model.addAttribute("name",user.getName());
-        }
-
         if(keyword==null) {
 
             keyword = "healing";
 
         }
 
-        String userKeyword = null;
-        List<Package> recommend = null;
-
+        List<Package> recommend = new ArrayList<>();
 
         if(principal!=null) {
 
@@ -77,9 +70,14 @@ public class HomeController {
                 Member member = memberService.getName(principal.getName());
 
                 name = member.getName();
-                userKeyword = member.getKeyword();
 
-                recommend = packageService.getSearch(userKeyword);
+                List<String> userKeyword = Arrays.asList(member.getKeyword().split(","));
+
+                recommend = packageService.getKeyword(userKeyword);
+
+                Collections.shuffle(recommend);
+
+                model.addAttribute("recommend",recommend);
 
             } else {
 
@@ -87,12 +85,11 @@ public class HomeController {
             }
         }
 
-
-
         List<Package> theme = packageService.getSearch(keyword);
+        Collections.shuffle(theme);
 
         System.out.println("패키지 사이즈"+theme.size());
-        model.addAttribute("recommend",recommend);
+
         model.addAttribute("name",name);
         model.addAttribute("theme",theme);
         model.addAttribute("keyword",keyword);
@@ -106,6 +103,8 @@ public class HomeController {
         List<Package> theme = packageService.getSearch(keyword);
 
         System.out.println("패키지 사이즈"+theme.size());
+
+        Collections.shuffle(theme);
 
         model.addAttribute("theme",theme);
         model.addAttribute("keyword",keyword);

--- a/src/main/java/com/project/tour/domain/Package.java
+++ b/src/main/java/com/project/tour/domain/Package.java
@@ -1,5 +1,6 @@
 package com.project.tour.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Getter;
 import lombok.Setter;
 

--- a/src/main/java/com/project/tour/repository/PackageRepository.java
+++ b/src/main/java/com/project/tour/repository/PackageRepository.java
@@ -15,11 +15,11 @@ public interface PackageRepository extends JpaRepository<Package,Long> {
 
     Optional<Package> findById(long id);
     Package findByPackageName(String packageName);
-    Package findByKeyword(String keyword);
-
     Page<Package> findAll(Pageable pageable);
 
     List<Package> findByIdIn(List<Long> packageNums);
     Page<Package> findByIdIn(Set<Long> packageNums, Pageable pageable);
+
+    List<Package> findByKeywordIn(List<String> keyword);
 
 }

--- a/src/main/java/com/project/tour/service/PackageService.java
+++ b/src/main/java/com/project/tour/service/PackageService.java
@@ -48,6 +48,15 @@ public class PackageService {
 
         return jejuRepository.findAll(spec);
     }
+
+    public List<Package> getKeyword(List<String> keyword){
+
+
+        return packageRepository.findByKeywordIn(keyword);
+    }
+
+
+
     public Page<Package> getSearchList(String location, String date, Integer count, String keyword,
                                        List<String> transport, List<Integer> period, Integer pricerangestr, Integer pricerangeend ,
                                        Pageable pageable) {

--- a/src/main/resources/templates/main.html
+++ b/src/main/resources/templates/main.html
@@ -286,8 +286,8 @@
                          aria-labelledby="nav-[[${keyword}]]-tab">
                         <div class="row" id="viewTable">
 
-                            <th:block th:each="package,loop:${theme}" th:if="${keyword}==healing">
-                                <div class="col-lg-3 col-md-6 col-sm-6 col-12"  >
+                            <th:block th:each="package,loop:${theme}"  th:if="${loop.index<4}">
+                                <div class="col-lg-3 col-md-6 col-sm-6 col-12" th:if="${keyword}==healing" >
                                     <div class="theme_common_box_two img_hover">
                                         <div class="theme_two_box_img">
                                             <a th:href="@{|/package/${package.id}|}">
@@ -306,8 +306,8 @@
                                 </div>
                             </th:block>
 
-                            <th:block th:each="package,loop:${theme}" th:if="${keyword}==activity">
-                                <div class="col-lg-3 col-md-6 col-sm-6 col-12">
+                            <th:block th:each="package,loop:${theme}" th:if="${loop.index<4}">
+                                <div class="col-lg-3 col-md-6 col-sm-6 col-12" th:if="${keyword}==activity">
                                     <div class="theme_common_box_two img_hover">
                                         <div class="theme_two_box_img">
                                             <a th:href="@{|/package/${package.id}|}">
@@ -326,8 +326,8 @@
                                 </div>
                             </th:block>
 
-                            <th:block th:each="package,loop:${theme}" th:if="${keyword}==food">
-                                <div class="col-lg-3 col-md-6 col-sm-6 col-12">
+                            <th:block th:each="package,loop:${theme}" th:if="${loop.index<4}">
+                                <div class="col-lg-3 col-md-6 col-sm-6 col-12" th:if="${keyword}==food">
                                     <div class="theme_common_box_two img_hover">
                                         <div class="theme_two_box_img">
                                             <a th:href="@{|/package/${package.id}|}">
@@ -346,8 +346,8 @@
                                 </div>
                             </th:block>
 
-                            <th:block th:each="package,loop:${theme}" th:if="${keyword}==culture">
-                                <div class="col-lg-3 col-md-6 col-sm-6 col-12">
+                            <th:block th:each="package,loop:${theme}" th:if="${loop.index<4}">
+                                <div class="col-lg-3 col-md-6 col-sm-6 col-12" th:if="${keyword}==culture">
                                     <div class="theme_common_box_two img_hover">
                                         <div class="theme_two_box_img">
                                             <a th:href="@{|/package/${package.id}|}">
@@ -565,7 +565,7 @@
                         </div>
                     </div>
 
-                    <th:block th:each="recom : ${recommend}" th:if="${recomStat.index<3}">
+                    <th:block th:each="recom : ${recommend}" th:if="${recomStat.index<6}">
                         <div class="col-lg-4">
                             <div class="holiday_small_boxed">
                                 <a th:href="@{|/package/${recom.id}|}">


### PR DESCRIPTION
회원가입시 선택한 선호 키워드가 1개일때만 리스트가 출력되었던 부분을
선호 키워드가 여러개여도 해당 키워드들로 모두 select한 패키지 리스트 출력하도록 수정함 맞춤형 패키지는 최대 6개까지만 노출되도록 수정함
메인페이지의 테마별 패키지 추천 리스트와 회원별 맞춤형 패키지 추천 리스트 모두 index가 랜덤으로 출력되도록 하여 새로고침시마다 추천 패키지가 바뀌도록 수정함